### PR TITLE
Potential fix for code scanning alert no. 16: Server-side request forgery

### DIFF
--- a/srv/sql_injection1.js
+++ b/srv/sql_injection1.js
@@ -61,7 +61,11 @@ app.get('/proxy', (req, res) => {
 // 🧱 Issue 7: Incomplete Sanitization Using substring (CWE-020)
 app.get('/fetch-item', (req, res) => {
   const item = req.query.item;
-  const url = 'https://api.example.com/items/' + item.substring(0, 5); // Weak validation
+  // Validate item: only allow alphanumeric, underscore, and hyphen, max 5 chars
+  if (!item || !/^[a-zA-Z0-9_-]{1,5}$/.test(item)) {
+    return res.status(400).send('Invalid item parameter');
+  }
+  const url = 'https://api.example.com/items/' + item;
   axios.get(url)
     .then(r => res.send(r.data))
     .catch(e => res.status(500).send(e.message));


### PR DESCRIPTION
Potential fix for [https://github.com/mohith140/SONAR_CAP/security/code-scanning/16](https://github.com/mohith140/SONAR_CAP/security/code-scanning/16)

To fix the SSRF vulnerability, we should avoid using raw user input in the construction of the URL path. The best approach is to validate the `item` parameter against a strict allow-list of permitted item IDs or names, or at least ensure it matches a safe pattern (e.g., alphanumeric only, no special characters, no path traversal). This prevents attackers from manipulating the path to access unintended resources. The fix should be applied in the `/fetch-item` route handler, specifically where `item` is read and used to construct the URL. We can use a regular expression to allow only safe characters (e.g., `/^[a-zA-Z0-9_-]{1,5}$/`), and reject any input that does not match. If the input is invalid, return a 400 Bad Request error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
